### PR TITLE
Bugfixes on brcmfmac for 5.15/6.1

### DIFF
--- a/patches/driver/brcmfmac_5.15.y-nexmon/cfg80211.c
+++ b/patches/driver/brcmfmac_5.15.y-nexmon/cfg80211.c
@@ -739,7 +739,8 @@ static struct wireless_dev *brcmf_cfg80211_add_iface(struct wiphy *wiphy,
 	case NL80211_IFTYPE_MESH_POINT:
 		return ERR_PTR(-EOPNOTSUPP);
 	case NL80211_IFTYPE_MONITOR:
-		return brcmf_mon_add_vif(wiphy, name, params);
+		wdev = brcmf_mon_add_vif(wiphy, name, params);
+		break;
 	case NL80211_IFTYPE_AP:
 		wdev = brcmf_ap_add_vif(wiphy, name, params);
 		break;

--- a/patches/driver/brcmfmac_5.15.y-nexmon/core.c
+++ b/patches/driver/brcmfmac_5.15.y-nexmon/core.c
@@ -839,18 +839,10 @@ static int brcmf_net_mon_stop(struct net_device *ndev)
 	return err;
 }
 
-static netdev_tx_t brcmf_net_mon_start_xmit(struct sk_buff *skb,
-					    struct net_device *ndev)
-{
-	dev_kfree_skb_any(skb);
-
-	return NETDEV_TX_OK;
-}
-
 static const struct net_device_ops brcmf_netdev_ops_mon = {
 	.ndo_open = brcmf_net_mon_open,
 	.ndo_stop = brcmf_net_mon_stop,
-	.ndo_start_xmit = brcmf_net_mon_start_xmit,
+	.ndo_start_xmit = brcmf_netdev_start_xmit,
 };
 
 int brcmf_net_mon_attach(struct brcmf_if *ifp)

--- a/patches/driver/brcmfmac_6.1.y-nexmon/cfg80211.c
+++ b/patches/driver/brcmfmac_6.1.y-nexmon/cfg80211.c
@@ -739,7 +739,8 @@ static struct wireless_dev *brcmf_cfg80211_add_iface(struct wiphy *wiphy,
 	case NL80211_IFTYPE_MESH_POINT:
 		return ERR_PTR(-EOPNOTSUPP);
 	case NL80211_IFTYPE_MONITOR:
-		return brcmf_mon_add_vif(wiphy, name, params);
+		wdev = brcmf_mon_add_vif(wiphy, name, params);
+		break;
 	case NL80211_IFTYPE_AP:
 		wdev = brcmf_ap_add_vif(wiphy, name, params);
 		break;

--- a/patches/driver/brcmfmac_6.1.y-nexmon/core.c
+++ b/patches/driver/brcmfmac_6.1.y-nexmon/core.c
@@ -827,18 +827,10 @@ static int brcmf_net_mon_stop(struct net_device *ndev)
 	return err;
 }
 
-static netdev_tx_t brcmf_net_mon_start_xmit(struct sk_buff *skb,
-					    struct net_device *ndev)
-{
-	dev_kfree_skb_any(skb);
-
-	return NETDEV_TX_OK;
-}
-
 static const struct net_device_ops brcmf_netdev_ops_mon = {
 	.ndo_open = brcmf_net_mon_open,
 	.ndo_stop = brcmf_net_mon_stop,
-	.ndo_start_xmit = brcmf_net_mon_start_xmit,
+	.ndo_start_xmit = brcmf_netdev_start_xmit,
 };
 
 int brcmf_net_mon_attach(struct brcmf_if *ifp)


### PR DESCRIPTION
Fix injection (drivers were using a dummy function instead of the right one) and another minor fix in brcmf_cfg80211_add_iface